### PR TITLE
Introduce Automated Docker Build & Push Workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every Sunday
+    - cron: '0 0 * * 0'
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true 
+          tags: distrolessdevops/nginx-distroless:latest 
+
+  push:
+    runs-on: self-hosted
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: distrolessdevops/nginx-distroless:latest
+
+      - name: Logout from Docker Hub
+        if: always()
+        run: docker logout


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow for automating Docker builds and pushes. The workflow is configured to:
1. Build the Docker image on every pull request to main and on every push to main.
2. Push the built image to Docker Hub, but only for pushes to main (not on PRs).
3. Execute on self-hosted runners for enhanced control and performance.
4. Schedule a weekly build every Sunday at 00:00 UTC.

Changes are encapsulated in the .github/workflows/docker-publish.yml file.

This enhancement ensures consistent Docker image building and streamlined deployment.